### PR TITLE
ascii_ext: fix bindings_with_variant_name warning when using this crate in Mononoke

### DIFF
--- a/shed/ascii_ext/src/lib.rs
+++ b/shed/ascii_ext/src/lib.rs
@@ -32,8 +32,8 @@ impl Deref for AsciiString {
 }
 
 impl From<ascii::AsciiString> for AsciiString {
-    fn from(s: ascii::AsciiString) -> Self {
-        AsciiString(s)
+    fn from(ch: ascii::AsciiString) -> Self {
+        AsciiString(ch)
     }
 }
 


### PR DESCRIPTION
The following error happens when trying to build Mononoke:

```
error[E0170]: pattern binding `s` is named the same as one of the variants of the type `ascii::ascii_char::AsciiChar`
  --> shed/ascii_ext/src/lib.rs:88:13
   |
88 |     fn from(s: ascii::AsciiChar) -> Self {
   |             ^ help: to match on the variant, qualify the path: `ascii::ascii_char::AsciiChar::s`
   |
note: the lint level is defined here
  --> shed/ascii_ext/src/lib.rs:11:9
   |
11 | #![deny(warnings, missing_docs, clippy::all, intra_doc_link_resolution_failure)]
   |         ^^^^^^^^
   = note: `#[deny(bindings_with_variant_name)]` implied by `#[deny(warnings)]`
```

It is unknown why this error happens only when ascii_ext is builded as dependency and as standalone.