### PR TITLE
Update outdated documentation for slog_glog_fmt

### DIFF
--- a/shed/slog_glog_fmt/src/kv_categorizer.rs
+++ b/shed/slog_glog_fmt/src/kv_categorizer.rs
@@ -52,8 +52,10 @@ impl KVCategorizer for InlineCategorizer {
 
 /// Used to properly print `error_chain` `Error`s. It displays the error and it's causes in
 /// separate log lines as well as backtrace if provided.
-/// The `error_chain` `Error` must implement `KV` trait. It is recommended to use `impl_kv_error`
-/// macro to generate the implementation.
+/// The `error_chain` `Error` must implement `KV` trait. It is recommended to
+/// wrap your error with `failure_ext::SlogKVError` to get this implementation
+/// for free. Example:
+///     error!(&logger, "Some error message"; SlogKVError(err))
 pub struct ErrorCategorizer;
 impl KVCategorizer for ErrorCategorizer {
     fn categorize(&self, key: Key) -> KVCategory {


### PR DESCRIPTION
Summary:
This documentation appears to have been outdated.
I'm updating to make clear how to properly get the
key-value pairs for errors to send to logview.

Differential Revision: D22169552

