### PR TITLE
Back out "fix boost macOS build with new Xcode"

### DIFF
--- a/build/fbcode_builder/manifests/boost
+++ b/build/fbcode_builder/manifests/boost
@@ -81,6 +81,3 @@ builder = boost
 --with-timer
 --with-type_erasure
 --with-wave
-
-[b2.args.os=darwin]
-toolset=clang


### PR DESCRIPTION
Summary:
Original commit changeset: 0b3d22835abb
Original diff: D22417488 (https://github.com/facebookexperimental/rust-shed/commit/99c7033589bc15884c39bb3f3ae58669943bc2e0)

Reviewed By: markbt

Differential Revision: D22571972

