### PR TITLE
mononoke/integration: build EdenSCM with non system OpenSSL (#63)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,8 +53,6 @@ jobs:
       continue-on-error: true
   mac:
     runs-on: macOS-latest
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_10.3.app/Contents/Developer
     steps:
     - uses: actions/checkout@v1
     - name: Install Rust Stable

--- a/build/fbcode_builder/getdeps/buildopts.py
+++ b/build/fbcode_builder/getdeps/buildopts.py
@@ -269,12 +269,11 @@ class BuildOptions(object):
                 env["RUSTC"] = rustc_path
                 env["RUSTDOC"] = rustdoc_path
 
-            if self.is_windows():
-                libcrypto = os.path.join(d, "lib/libcrypto.lib")
-            else:
-                libcrypto = os.path.join(d, "lib/libcrypto.so")
             openssl_include = os.path.join(d, "include/openssl")
-            if os.path.isfile(libcrypto) and os.path.isdir(openssl_include):
+            if os.path.isdir(openssl_include) and any(
+                os.path.isfile(os.path.join(d, "lib", libcrypto))
+                for libcrypto in ("libcrypto.lib", "libcrypto.so", "libcrypto.a")
+            ):
                 # This must be the openssl library, let Rust know about it
                 env["OPENSSL_DIR"] = d
 


### PR DESCRIPTION
Summary:
The OpenSSL version on Mac doesn't work well with EdenSCM and Mononoke integration, just use the one from getdeps/brew.

Also remove the now redundant "DEVELOPER_DIR" since the modern XCode version works.

Pull Request resolved: https://github.com/facebookexperimental/eden/pull/63

Differential Revision: D23927022

Pulled By: lukaspiatkowski

