### PR TITLE
rust/oss: update rustc version to 1.47 in rust-shed and eden GitHub workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install Rust Stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.44.0
+        toolchain: 1.47.0
         default: true
         profile: minimal
     - name: Install system deps
@@ -58,7 +58,7 @@ jobs:
     - name: Install Rust Stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.44.0
+        toolchain: 1.47.0
         default: true
         profile: minimal
     - name: Install system deps
@@ -100,7 +100,7 @@ jobs:
     - name: Install Rust Stable
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.44.0
+        toolchain: 1.47.0
         default: true
         profile: minimal
     - name: Export boost environment


### PR DESCRIPTION
Summary: Internal codebase was updated to 1.47 with code changes that are no longer compatible with 1.44. Updating to OSS 1.47 to fix build.

Reviewed By: ikostia, mzr

Differential Revision: D24389087

