### PR TITLE
Use async mutex for global sqlite lock to prevent deadlocks

### DIFF
--- a/shed/sql/Cargo.toml
+++ b/shed/sql/Cargo.toml
@@ -13,11 +13,12 @@ futures_ext = { path = "../futures_ext" }
 sql_common = { path = "common" }
 anyhow = "1.0"
 failure = "0.1"
-futures = "0.1"
+futures-old = { package = "futures", version = "0.1" }
 futures-util = "0.3"
 mysql_async = { version = "0.23" }
 rusqlite = { version = "0.23", features = ["blob", "bundled"] }
 
 [dev-dependencies]
 sql_tests_lib = { path = "tests_lib" }
+futures = { version = "0.3.5", features = ["async-await", "compat"] }
 tokio = { version = "=0.2.13", features = ["full"] }


### PR DESCRIPTION
Summary:
Testing code that uses transactions easily deadlocks, which prevents us from actually testing that transactions work as expected.

Rewriting `SqliteConnectionGuard` to use async-mutex for the global lock prevents deadlocks on concurrent transactions.

Reviewed By: lukaspiatkowski

Differential Revision: D24335275

