### PR TITLE
allow dead code so oss builds

### DIFF
--- a/shed/cachelib_stub/src/oss/lrucache.rs
+++ b/shed/cachelib_stub/src/oss/lrucache.rs
@@ -196,6 +196,7 @@ impl<'a> LruCacheRemoteHandle<'a> {
 
 #[derive(Clone)]
 pub struct LruCachePool {
+    #[allow(dead_code)]
     pool_name: String,
 }
 
@@ -293,6 +294,7 @@ impl LruCachePool {
 
 #[derive(Clone)]
 pub struct VolatileLruCachePool {
+    #[allow(dead_code)]
     inner: LruCachePool,
 }
 


### PR DESCRIPTION
the stub for cachelib_stub oss throws a field is never read error. These changes allow the oss build to continue.