### PR TITLE
patched mysql_async v0.27.1 with features passed to mio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [patch.crates-io]
 daemonize = { git = "https://github.com/krallin/daemonize", rev = "f7be28efa1b4a70e43bb37b5f4ff4d664992edca" }
 lru-disk-cache = { git = "https://github.com/mozilla/sccache", rev = "033ebaae69beeb0ac04e8c35d6ff1103487bd9a3" }
+mysql_async = { git = "https://github.com/mzr/mysql_async", rev = "76b6fa05d7bb3408402033e6f94042a756ab55ab" }
 prost = { git = "https://github.com/gabrielrussoc/prost", branch = "protoc-runtime" }
 prost-derive = { git = "https://github.com/gabrielrussoc/prost", branch = "protoc-runtime" }
 prost-types = { git = "https://github.com/gabrielrussoc/prost", branch = "protoc-runtime" }


### PR DESCRIPTION
Summary:
mysql_async 0.27.1 by itself doesn't enable necessary features on mio. Let's add it as a dummy dependency so we can enable these features manually.
This results in edenfs, eden_scm and mononoke builds fail on GH:

https://github.com/facebookexperimental/eden/runs/5221114887?check_suite_focus=true
https://github.com/facebookexperimental/eden/runs/5221114892?check_suite_focus=true
https://github.com/facebookexperimental/eden/runs/5221114891?check_suite_focus=true
https://github.com/facebookexperimental/eden/runs/5221114960?check_suite_focus=true

Differential Revision: D34309906

