### PR TITLE
Fix OSS build unexpected `cfg` condition name: `fbcode_build` failure

### DIFF
--- a/shed/cached_config/Cargo.toml
+++ b/shed/cached_config/Cargo.toml
@@ -23,3 +23,6 @@ tokio = { version = "1.37.0", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 serde_derive = "1.0.185"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }

--- a/shed/cachelib_stub/Cargo.toml
+++ b/shed/cachelib_stub/Cargo.toml
@@ -14,3 +14,6 @@ license = "MIT OR Apache-2.0"
 abomonation = { version = "0.7", features = ["smallvec"] }
 anyhow = "1.0.75"
 bytes = { version = "1.6.0", features = ["serde"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }

--- a/shed/failure_ext/Cargo.toml
+++ b/shed/failure_ext/Cargo.toml
@@ -17,3 +17,6 @@ slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }
 
 [dev-dependencies]
 thiserror = "1.0.49"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }

--- a/shed/fbinit/Cargo.toml
+++ b/shed/fbinit/Cargo.toml
@@ -24,3 +24,6 @@ quickcheck = "1.0"
 
 [dev-dependencies]
 fbinit-tokio = { version = "0.1.2", path = "fbinit-tokio" }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }

--- a/shed/hostname/Cargo.toml
+++ b/shed/hostname/Cargo.toml
@@ -13,3 +13,6 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow = "1.0.75"
 real_hostname = { package = "hostname", version = "0.3" }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }

--- a/shed/memcache_stub/Cargo.toml
+++ b/shed/memcache_stub/Cargo.toml
@@ -12,3 +12,6 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 memcache_common = { version = "0.1.0", path = "common" }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }

--- a/shed/ods/Cargo.toml
+++ b/shed/ods/Cargo.toml
@@ -13,3 +13,6 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow = "1.0.75"
 fbinit = { version = "0.1.2", path = "../fbinit" }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }

--- a/shed/scuba_stub/Cargo.toml
+++ b/shed/scuba_stub/Cargo.toml
@@ -12,3 +12,6 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 scuba_sample = { version = "0.1.0", path = "../scuba_sample" }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }

--- a/shed/secure_utils/Cargo.toml
+++ b/shed/secure_utils/Cargo.toml
@@ -19,3 +19,6 @@ openssl-sys = "0.9.97"
 serde = { version = "1.0.185", features = ["derive", "rc"] }
 serde_json = { version = "1.0.100", features = ["float_roundtrip", "unbounded_depth"] }
 slog = { version = "2.7", features = ["max_level_trace", "nested-values"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }

--- a/shed/services/Cargo.toml
+++ b/shed/services/Cargo.toml
@@ -13,3 +13,6 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 fbinit = { version = "0.1.2", path = "../fbinit" }
 services_common = { version = "0.1.0", path = "common" }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }

--- a/shed/services/common/Cargo.toml
+++ b/shed/services/common/Cargo.toml
@@ -17,3 +17,6 @@ path = "lib.rs"
 [dependencies]
 cxx = "1.0.119"
 thiserror = "1.0.49"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }

--- a/shed/sql/common/Cargo.toml
+++ b/shed/sql/common/Cargo.toml
@@ -36,3 +36,6 @@ sql_tests_lib = { version = "0.1.0", path = "../tests_lib" }
 
 [features]
 default = ["rusqlite/bundled"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }

--- a/shed/stats/Cargo.toml
+++ b/shed/stats/Cargo.toml
@@ -18,3 +18,6 @@ perthread = { version = "0.1.0", path = "../perthread" }
 stats_traits = { version = "0.1.0", path = "traits" }
 tokio = { version = "1.37.0", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1.14", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }


### PR DESCRIPTION
Summary:
The latest stable (rustc 1.80) enables checking for all cfg names and values that it knows https://blog.rust-lang.org/2024/07/25/Rust-1.80.0.html#checked-cfg-names-and-values, add lint to Cargo.toml to fix unexpected_cfgs error.

Test Plan:
```
./build/fbcode_builder/getdeps.py build --allow-system-packages --no-facebook-internal --src-dir . rust-shed
```