### PR TITLE
: rust: rustls/tokio-rustls patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,11 @@ protobuf-build = { git = "https://github.com/fbsource/protobuf-build", rev = "ee
 quickcheck = { git = "https://github.com/jakoschiko/quickcheck", rev = "6ecdf5bb4b0132ce66670b4d46453aa022ea892c" }
 ratatui = { git = "https://github.com/fbsource/ratatui", rev = "2c4576ee123b2ac4845bd4a823af721ac447b33f" }
 rinja = { git = "https://github.com/fbsource/askama", rev = "2fc6173c98034c148f46330fc39a006cf0b09efe" }
+rustls = { git = "https://github.com/shayne-fletcher/rustls", rev = "796f631997bff19617a890a69dbccc3ec3f51284" }
 sqlx = { git = "https://github.com/launchbadge/sqlx", rev = "24317d5eab40fbc33caf1142946e2f39caad73ea" }
 stabby = { git = "https://github.com/fbsource/stabby", rev = "22db1dda19938ff7725a93db64012a5730325c5d" }
 tokenizers-21 = { package = "tokenizers", git = "https://github.com/huggingface/tokenizers", rev = "133db48d4f272070076fbc7a649c9e8aa8cd0646" }
+tokio-rustls = { git = "https://github.com/shayne-fletcher/tokio-rustls", rev = "62b6a48e4c14a05c193508b9d98a0be6b0cb4baa" }
 uefisettings = { git = "https://github.com/linuxboot/uefisettings", rev = "f16daed1d2bd1216204fd24e876c6477d03aebb3" }
 vm-allocator = { git = "https://github.com/rust-vmm/vm-allocator", rev = "5fb545cc6e41fdc9f27d48d97ed26274a35bc6c6" }
 warp = { git = "https://github.com/jdthomas/warp.git", rev = "c794232d182abaa3add8184e7d661e084cc516c5" }


### PR DESCRIPTION
Summary:
X-link: https://github.com/pytorch-labs/monarch/pull/640

a critical perf issue in tokio-rustls was discovered during monarch testing. we will work with upstream to get patches for it landed.

during the transition this diff updates `fbsource/third-party/rust/Cargo.toml` to pull patched versions of (1) [`tokio-rustls v0.24.1`](https://github.com/shayne-fletcher/tokio-rustls/tree/meta-perf-fix-v0.24.1)  and (2) [`rustls v0.21.12`](https://github.com/shayne-fletcher/rustls/tree/meta-perf-fix-v.0.21.12).

Reviewed By: dtolnay

Differential Revision: D78929040


