### PR TITLE
Update futures family to 0.3.32

### DIFF
--- a/shed/async_once_cell/Cargo.toml
+++ b/shed/async_once_cell/Cargo.toml
@@ -13,5 +13,5 @@ license = "MIT OR Apache-2.0"
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 rand = { version = "0.9", features = ["small_rng"] }

--- a/shed/bounded_traversal/Cargo.toml
+++ b/shed/bounded_traversal/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 either = "1.5"
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 smallvec = { version = "1.15", features = ["impl_bincode", "serde", "specialization", "union"] }
 thiserror = "2.0.18"
 

--- a/shed/buffered_weighted/Cargo.toml
+++ b/shed/buffered_weighted/Cargo.toml
@@ -16,7 +16,7 @@ pin-project = "1.1.10"
 weight_observer = "0.1.0"
 
 [dev-dependencies]
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 proptest = "1.5"
 proptest-derive = "0.5"
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }

--- a/shed/facet/Cargo.toml
+++ b/shed/facet/Cargo.toml
@@ -49,7 +49,7 @@ path = "test/tuple_struct_test.rs"
 anyhow = "1.0.98"
 async-trait = "0.1.86"
 facet_proc_macros = { version = "0.1.0", path = "proc_macros" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 thiserror = "2.0.18"
 trait-set = "0.3.0"
 

--- a/shed/fbinit/fbinit-tokio/Cargo.toml
+++ b/shed/fbinit/fbinit-tokio/Cargo.toml
@@ -13,5 +13,5 @@ license = "MIT OR Apache-2.0"
 path = "lib.rs"
 
 [dependencies]
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }

--- a/shed/fbthrift_ext/framed/Cargo.toml
+++ b/shed/fbthrift_ext/framed/Cargo.toml
@@ -19,5 +19,5 @@ bytes = { version = "1.11.1", features = ["serde"] }
 tokio-util = { version = "0.7.15", features = ["full"] }
 
 [dev-dependencies]
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }

--- a/shed/fbthrift_ext/socket/Cargo.toml
+++ b/shed/fbthrift_ext/socket/Cargo.toml
@@ -19,7 +19,7 @@ bytes = { version = "1.11.1", features = ["serde"] }
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 fbthrift_framed = { version = "0.1.0", path = "../framed" }
 fbthrift_util = { version = "0.1.0", path = "../util" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tokio-tower = "0.6"
 tokio-util = { version = "0.7.15", features = ["full"] }

--- a/shed/fbthrift_ext/tcp/Cargo.toml
+++ b/shed/fbthrift_ext/tcp/Cargo.toml
@@ -19,7 +19,7 @@ bytes = { version = "1.11.1", features = ["serde"] }
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 fbthrift_framed = { version = "0.1.0", path = "../framed" }
 fbthrift_util = { version = "0.1.0", path = "../util" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 tokio-tower = "0.6"
 tokio-util = { version = "0.7.15", features = ["full"] }

--- a/shed/futures_01_ext/Cargo.toml
+++ b/shed/futures_01_ext/Cargo.toml
@@ -17,5 +17,5 @@ futures = "0.1.31"
 anyhow = "1.0.98"
 assert_matches = "1.5"
 cloned = { version = "0.1.0", path = "../cloned" }
-futures03 = { package = "futures", version = "0.3.31", features = ["async-await", "compat"] }
+futures03 = { package = "futures", version = "0.3.32", features = ["async-await", "compat"] }
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }

--- a/shed/futures_ext/Cargo.toml
+++ b/shed/futures_ext/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 anyhow = "1.0.98"
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 pin-project = "1.1.10"
 shared_error = { version = "0.1.0", path = "../shared_error" }
 thiserror = "2.0.18"

--- a/shed/futures_lazy_shared/Cargo.toml
+++ b/shed/futures_lazy_shared/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/facebookexperimental/rust-shed"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 
 [dev-dependencies]
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }

--- a/shed/futures_stats/Cargo.toml
+++ b/shed/futures_stats/Cargo.toml
@@ -15,6 +15,6 @@ name = "futures_stats_test"
 path = "test/main.rs"
 
 [dependencies]
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 futures_ext = { version = "0.1.0", path = "../futures_ext" }
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }

--- a/shed/justknobs_stub/Cargo.toml
+++ b/shed/justknobs_stub/Cargo.toml
@@ -18,7 +18,7 @@ path = "tests/justknobs_in_unittest.rs"
 anyhow = "1.0.98"
 arc-swap = { version = "1.5", features = ["weak"] }
 cached_config = { version = "0.1.0", path = "../cached_config" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 just_knobs_struct = { version = "0.1.0", path = "cached_config_thrift_struct" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }

--- a/shed/justknobs_stub/cached_config_thrift_struct/Cargo.toml
+++ b/shed/justknobs_stub/cached_config_thrift_struct/Cargo.toml
@@ -20,7 +20,7 @@ doc = false
 anyhow = "1.0.98"
 codegen_includer_proc_macro = { version = "0.1.0", path = "../../codegen_includer_proc_macro" }
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 ref-cast = "1.0.18"
 rust = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }

--- a/shed/justknobs_stub/cached_config_thrift_struct/clients/Cargo.toml
+++ b/shed/justknobs_stub/cached_config_thrift_struct/clients/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", path = "../../../codegen_includer_proc_macro" }
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 just_knobs_struct__types = { package = "just_knobs_struct", version = "0.1.0", path = ".." }
 rust = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 rust_clients = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }

--- a/shed/justknobs_stub/cached_config_thrift_struct/mocks/Cargo.toml
+++ b/shed/justknobs_stub/cached_config_thrift_struct/mocks/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", path = "../../../codegen_includer_proc_macro" }
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 just_knobs_struct__clients = { package = "just_knobs_struct_clients", version = "0.1.0", path = "../clients" }
 just_knobs_struct__types = { package = "just_knobs_struct", version = "0.1.0", path = ".." }
 rust = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }

--- a/shed/justknobs_stub/cached_config_thrift_struct/services/Cargo.toml
+++ b/shed/justknobs_stub/cached_config_thrift_struct/services/Cargo.toml
@@ -21,7 +21,7 @@ anyhow = "1.0.98"
 async-trait = "0.1.86"
 codegen_includer_proc_macro = { version = "0.1.0", path = "../../../codegen_includer_proc_macro" }
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 just_knobs_struct__types = { package = "just_knobs_struct", version = "0.1.0", path = ".." }
 rust = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 rust_services = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }

--- a/shed/sql/Cargo.toml
+++ b/shed/sql/Cargo.toml
@@ -14,8 +14,8 @@ license = "MIT OR Apache-2.0"
 anyhow = "1.0.98"
 cloned = { version = "0.1.0", path = "../cloned" }
 frunk = "0.4.4"
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
-futures-util = { version = "0.3.30", features = ["compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
+futures-util = { version = "0.3.32", features = ["compat"] }
 futures_ext = { version = "0.1.0", path = "../futures_ext" }
 mysql_async = "0.31.2"
 mysql_common = { version = "0.29.0", features = ["chrono", "default"] }

--- a/shed/sql/common/Cargo.toml
+++ b/shed/sql/common/Cargo.toml
@@ -17,7 +17,7 @@ path = "lib.rs"
 anyhow = "1.0.98"
 async-trait = "0.1.86"
 cloned = { version = "0.1.0", path = "../../cloned" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 futures_stats = { version = "0.1.0", path = "../../futures_stats" }
 itertools = "0.14.0"
 mysql_async = "0.31.2"

--- a/shed/stats/Cargo.toml
+++ b/shed/stats/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 fbinit = { version = "0.2.0", path = "../fbinit" }
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 perthread = { version = "0.1.0", path = "../perthread" }
 stats_traits = { version = "0.1.0", path = "traits" }
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }

--- a/shed/tokio-uds-compat/Cargo.toml
+++ b/shed/tokio-uds-compat/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 tokio = { version = "1.47.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
+futures = { version = "0.3.32", features = ["async-await", "compat"] }
 
 [target.'cfg(windows)'.dependencies]
 async-io = "1.4.1"


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/hermit/pull/62

Update the futures family of Rust crates from 0.3.30/0.3.31 to 0.3.32: futures, futures-channel, futures-core, and futures-util. This is a minor version bump that includes upstream bug fixes and improvements.

Reviewed By: dtolnay

Differential Revision: D93684256
