### PR TITLE
Bump parking_lot crate from 0.12.1 to 0.12.3

### DIFF
--- a/shed/lock_ext/Cargo.toml
+++ b/shed/lock_ext/Cargo.toml
@@ -11,4 +11,4 @@ repository = "https://github.com/facebookexperimental/rust-shed"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-parking_lot = { version = "0.12.1", features = ["send_guard"] }
+parking_lot = { version = "0.12.3", features = ["send_guard"] }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookexperimental/reverie/pull/35

X-link: https://github.com/facebook/relay/pull/5253

Differential Revision: D100982156


