### PR TITLE
upgrading tokio to 1.52.1

### DIFF
--- a/shed/async_once_cell/Cargo.toml
+++ b/shed/async_once_cell/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/facebookexperimental/rust-shed"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 futures = { version = "0.3.31", features = ["async-await", "compat"] }

--- a/shed/async_process_traits/Cargo.toml
+++ b/shed/async_process_traits/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 async-trait = "0.1.86"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = { version = "0.30.1", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }

--- a/shed/bounded_traversal/Cargo.toml
+++ b/shed/bounded_traversal/Cargo.toml
@@ -23,4 +23,4 @@ maplit = "1.0"
 pretty_assertions = { version = "1.4.1", features = ["alloc"], default-features = false }
 quickcheck = "1.0"
 quickcheck_async = "0.1.1"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/shed/buffered_weighted/Cargo.toml
+++ b/shed/buffered_weighted/Cargo.toml
@@ -19,7 +19,7 @@ weight_observer = { version = "0.1.0", path = "../weight_observer" }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 proptest = "1.11.0"
 proptest-derive = "0.5.1"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1.18", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/shed/cached_config/Cargo.toml
+++ b/shed/cached_config/Cargo.toml
@@ -19,7 +19,7 @@ fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbth
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 slog = { package = "tracing_slog_compat", version = "0.1.0", path = "../tracing_slog_compat" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 serde_derive = "1.0.185"

--- a/shed/facet/Cargo.toml
+++ b/shed/facet/Cargo.toml
@@ -54,7 +54,7 @@ thiserror = "2.0.18"
 trait-set = "0.3.0"
 
 [dev-dependencies]
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [features]
 default = ["impl_never_type"]

--- a/shed/fbinit/fbinit-tokio/Cargo.toml
+++ b/shed/fbinit/fbinit-tokio/Cargo.toml
@@ -14,4 +14,4 @@ path = "lib.rs"
 
 [dependencies]
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/shed/fbthrift_ext/framed/Cargo.toml
+++ b/shed/fbthrift_ext/framed/Cargo.toml
@@ -20,4 +20,4 @@ tokio-util = { version = "0.7.18", features = ["full"] }
 
 [dev-dependencies]
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/shed/fbthrift_ext/socket/Cargo.toml
+++ b/shed/fbthrift_ext/socket/Cargo.toml
@@ -20,7 +20,7 @@ fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbth
 fbthrift_framed = { version = "0.1.0", path = "../framed" }
 fbthrift_util = { version = "0.1.0", path = "../util" }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-tower = "0.6"
 tokio-util = { version = "0.7.18", features = ["full"] }
 tower-service = "0.3.3"

--- a/shed/fbthrift_ext/tcp/Cargo.toml
+++ b/shed/fbthrift_ext/tcp/Cargo.toml
@@ -20,7 +20,7 @@ fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbth
 fbthrift_framed = { version = "0.1.0", path = "../framed" }
 fbthrift_util = { version = "0.1.0", path = "../util" }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-tower = "0.6"
 tokio-util = { version = "0.7.18", features = ["full"] }
 tower-service = "0.3.3"

--- a/shed/fbthrift_ext/util/Cargo.toml
+++ b/shed/fbthrift_ext/util/Cargo.toml
@@ -14,4 +14,4 @@ license = "MIT OR Apache-2.0"
 path = "lib.rs"
 
 [dependencies]
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/shed/futures_01_ext/Cargo.toml
+++ b/shed/futures_01_ext/Cargo.toml
@@ -18,4 +18,4 @@ anyhow = "1.0.102"
 assert_matches = "1.5"
 cloned = { version = "0.1.0", path = "../cloned" }
 futures03 = { package = "futures", version = "0.3.31", features = ["async-await", "compat"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/shed/futures_ext/Cargo.toml
+++ b/shed/futures_ext/Cargo.toml
@@ -16,7 +16,7 @@ futures = { version = "0.3.31", features = ["async-await", "compat"] }
 pin-project = "1.1.11"
 shared_error = { version = "0.1.0", path = "../shared_error" }
 thiserror = "2.0.18"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 assert_matches = "1.5"

--- a/shed/futures_lazy_shared/Cargo.toml
+++ b/shed/futures_lazy_shared/Cargo.toml
@@ -14,4 +14,4 @@ license = "MIT OR Apache-2.0"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 
 [dev-dependencies]
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/shed/futures_retry/Cargo.toml
+++ b/shed/futures_retry/Cargo.toml
@@ -12,4 +12,4 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 pin-project = "1.1.11"
 rand = "0.10"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/shed/futures_stats/Cargo.toml
+++ b/shed/futures_stats/Cargo.toml
@@ -17,4 +17,4 @@ path = "test/main.rs"
 [dependencies]
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 futures_ext = { version = "0.1.0", path = "../futures_ext" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }

--- a/shed/justknobs_stub/Cargo.toml
+++ b/shed/justknobs_stub/Cargo.toml
@@ -23,7 +23,7 @@ just_knobs_struct = { version = "0.1.0", path = "cached_config_thrift_struct" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 slog = { version = "2.8.2", features = ["max_level_trace", "nested-values"] }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tracing_slog_compat = { version = "0.1.0", path = "../tracing_slog_compat" }
 
 [dev-dependencies]

--- a/shed/sql/Cargo.toml
+++ b/shed/sql/Cargo.toml
@@ -26,7 +26,7 @@ sql_common = { version = "0.1.0", path = "common" }
 fbinit = { version = "0.2.0", path = "../fbinit" }
 fbinit-tokio = { version = "0.1.2", path = "../fbinit/fbinit-tokio" }
 sql_tests_lib = { version = "0.1.0", path = "tests_lib" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [features]
 default = ["mysql_common/chrono", "mysql_common/default"]

--- a/shed/sql/common/Cargo.toml
+++ b/shed/sql/common/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw
 stats = { version = "0.1.0", path = "../../stats" }
 thiserror = "2.0.18"
 time_ext = { version = "0.1.0", path = "../../time_ext" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 vec1 = { version = "1.12.1", features = ["serde"] }
 
 [dev-dependencies]

--- a/shed/stats/Cargo.toml
+++ b/shed/stats/Cargo.toml
@@ -15,7 +15,7 @@ fbinit = { version = "0.2.0", path = "../fbinit" }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 perthread = { version = "0.1.0", path = "../perthread" }
 stats_traits = { version = "0.1.0", path = "traits" }
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 tokio-stream = { version = "0.1.18", features = ["fs", "io-util", "net", "signal", "sync", "time"] }
 
 [lints]

--- a/shed/tokio-detectors/Cargo.toml
+++ b/shed/tokio-detectors/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 rand = "0.10"
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2.183"

--- a/shed/tokio-uds-compat/Cargo.toml
+++ b/shed/tokio-uds-compat/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/facebookexperimental/rust-shed"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-tokio = { version = "1.50.0", features = ["full", "test-util", "tracing"] }
+tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 
 [dev-dependencies]
 futures = { version = "0.3.31", features = ["async-await", "compat"] }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/below/pull/8278

X-link: https://github.com/facebookexperimental/dapper/pull/1

X-link: https://github.com/meta-pytorch/monarch/pull/3495

Upgrading `tokio` from `1.50.0` to `1.52.1`.
- All downstream consumers checked with arc rust-check — 0 errors.

Reviewed By: dtolnay

Differential Revision: D101580193
