### PR TITLE
refresh 10 crates to latest compatible versions

### DIFF
--- a/shed/cached_config/Cargo.toml
+++ b/shed/cached_config/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow = "1.0.102"
 bytes = { version = "1.11.1", features = ["serde"] }
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 fbinit = { version = "0.2.0", path = "../fbinit" }
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 serde = { version = "1.0.219", features = ["derive", "rc"] }

--- a/shed/fbthrift_ext/adapters/Cargo.toml
+++ b/shed/fbthrift_ext/adapters/Cargo.toml
@@ -16,7 +16,7 @@ path = "lib.rs"
 [dependencies]
 bstr = { version = "1.10.0", features = ["serde", "std", "unicode"] }
 camino = { version = "1.2.2", features = ["serde1"] }
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 either = "1.5"
 fbthrift = { version = "0.0.1+unstable", git = "https://github.com/facebook/fbthrift.git", branch = "main" }
 ordered-float = { version = "4.6.0", features = ["serde"] }

--- a/shed/slog_glog_fmt/Cargo.toml
+++ b/shed/slog_glog_fmt/Cargo.toml
@@ -16,7 +16,7 @@ path = "example/main.rs"
 
 [dependencies]
 anyhow = "1.0.102"
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 failure_ext = { version = "0.1.0", path = "../failure_ext" }
 hostname = "0.4.2"
 itertools = "0.14.0"

--- a/shed/sql/mysql_client_traits/Cargo.toml
+++ b/shed/sql/mysql_client_traits/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 path = "lib.rs"
 
 [dependencies]
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 mysql_common = { version = "0.29.0", features = ["chrono", "default"] }
 seq-macro = "0.3.4"
 thiserror = "2.0.18"

--- a/shed/sql/tests_lib/Cargo.toml
+++ b/shed/sql/tests_lib/Cargo.toml
@@ -15,7 +15,7 @@ path = "lib.rs"
 
 [dependencies]
 anyhow = "1.0.102"
-chrono = { version = "0.4.44", features = ["clock", "serde", "std"], default-features = false }
+chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
 fbinit = { version = "0.2.0", path = "../../fbinit" }
 rand = "0.10.1"
 sql = { version = "0.1.0", path = ".." }


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebook/hhvm/pull/9791

X-link: https://github.com/facebook/ocamlrep/pull/93

X-link: https://github.com/facebook/buck2-shims-meta/pull/17

X-link: https://github.com/facebook/flow/pull/9420

X-link: https://github.com/WhatsApp/erlang-language-platform/pull/215

X-link: https://github.com/facebook/buck2/pull/1335

X-link: https://github.com/meta-pytorch/monarch/pull/4193

Refreshes 10 third-party Rust crates to their latest semver-compatible versions. These are dependencies used by the hzdb/metavr CLI (`arvr/apps/hzdb`) that were behind in the shared lockfile; the bumps apply repo-wide since `third-party/rust` is shared.

- `bitflags` `2.11.1` -> `2.13.0`
- `bumpalo` `3.20.2` -> `3.20.3`
- `cc` `1.2.62` -> `1.2.63` (additively vendors `shlex` `2.0.1` as a new transitive of `cc`)
- `chrono` `0.4.44` -> `0.4.45`
- `http` `1.4.0` -> `1.4.1`
- `hyper` `1.9.0` -> `1.10.1`
- `memchr` `2.8.0` -> `2.8.1`
- `reqwest` `0.13.2` -> `0.13.4`
- `unicode-segmentation` `1.13.2` -> `1.13.3`
- `zerocopy` `0.8.48` -> `0.8.50`

All are patch/minor (semver-compatible) bumps requiring no first-party code changes. Mirrored the applicable bumps into the github shim manifest (`fbcode/github/standard/shim/third-party/rust/Cargo.toml`) for `bitflags`, `bumpalo`, `chrono`, `http`, `hyper`, `memchr`, and `unicode-segmentation`. Regenerated with `reindeer vendor`, which also refreshed 255 first-party `Cargo.toml` manifests via autocargo. No first-party Rust source changes were needed.

Differential Revision: D107740437
